### PR TITLE
Upgrade commons-codec:commons-codec to version 1.13 or higher.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>net.kemitix.aws</groupId>
     <artifactId>kemitix-aws-java-sdk-s3-wrapper</artifactId>
-    <version>1.11.816</version><!-- must match ${aws-java-sdk-s2.version} -->
+    <version>1.11.820</version><!-- must match ${aws-java-sdk-s2.version} -->
 
     <description>
         Wrapper for the AWS Java SDK for S3 - only releases when there
@@ -21,7 +21,7 @@
     </description>
 
     <properties>
-        <aws-java-sdk-s3.version>1.11.816</aws-java-sdk-s3.version>
+        <aws-java-sdk-s3.version>${project.version}</aws-java-sdk-s3.version>
         <jackson-databind.version>2.11.1</jackson-databind.version>
         <jackson-dataformat-cbor.version>2.11.1</jackson-dataformat-cbor.version>
         <commons-logging.version>1.2</commons-logging.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <jackson-databind.version>2.11.1</jackson-databind.version>
         <jackson-dataformat-cbor.version>2.11.1</jackson-dataformat-cbor.version>
         <commons-logging.version>1.2</commons-logging.version>
+        <commons-codec.version>1.14</commons-codec.version>
 
         <maven-graph-plugin.version>1.45</maven-graph-plugin.version>
 
@@ -50,6 +51,10 @@
                     <artifactId>commons-logging</artifactId>
                     <groupId>commons-logging</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -66,6 +71,11 @@
             <artifactId>commons-logging</artifactId>
             <groupId>commons-logging</groupId>
             <version>${commons-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Affecting commons-codec:commons-codec artifact, versions [,1.13)

commons-codec:commons-codec is a package that contains simple encoder and decoders for various formats such as Base64 and Hexadecimal.

Affected versions of this package are vulnerable to Information Exposure. When there is no byte array value that can be encoded into a string the Base32 implementation does not reject it, and instead decodes it into an arbitrary value which can be re-encoded again using the same implementation. This allows for information exposure exploits such as tunneling additional information via seemingly valid base 32 strings.

Upgrade commons-codec:commons-codec to version 1.13 or higher.

* [GitHub Commit](apache/commons-codec@48b6157)
* [Jira Issue](https://issues.apache.org/jira/browse/CODEC-134)